### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -6,7 +6,7 @@ import Utils from '../modules/utils';
 exports.command = '*'
 exports.description = 'Docker-compose server site using .env to detect setup'
 
-exports.handler = function (argv: { [x: string]: any; base: string; debug: any; compose: any; }) {
+exports.handler = function (argv: { [x: string]: any; base: string; debug: any; docker: any; }) {
   const utils = new Utils();
   const docker = new Docker();
   const env = argv['env-file'];
@@ -29,7 +29,7 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
 
       case "--env-file":
       case "--base":
-      case "--compose":
+      case "--docker":
         // Jump over the argument to these parameteres
         i++
         continue;
@@ -43,6 +43,6 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
     docker.info(argv.debug, env, argv.base);
   }
   else {
-    docker.exec(argv.debug, env, argv.base, argv.compose, composeArguments)
+    docker.exec(argv.debug, env, argv.base, argv.docker, composeArguments)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ const argv = yargs(hideBin(process.argv))
             default: '.',
             type: 'string'
         },
-        'compose': {
-            description: 'Location of docker-compose executable',
-            default: '/usr/local/bin/docker-compose',
+        'docker': {
+            description: 'Location of docker executable',
+            default: '/usr/bin/docker',
             type: 'string'
         },
         'dump-info': {

--- a/src/modules/docker.ts
+++ b/src/modules/docker.ts
@@ -43,14 +43,15 @@ export default class Docker {
 	 *   The environment file to use.
 	 * @param base
 	 *   The base path to execute the command in.
-	 * @param compose
-	 *   The composer binary.
+	 * @param docker
+	 *   The docker binary.
 	 * @param composeArguments
 	 *   The commands to pass to docker compose.
 	 */
-	public exec(debug: boolean, env: string, base: string, compose: string, composeArguments: string[])
+	public exec(debug: boolean, env: string, base: string, docker: string, composeArguments: string[])
 	{
 		const args = [
+			'compose',
 			'--env-file', env
 		]
 
@@ -73,11 +74,11 @@ export default class Docker {
 
 		if (debug) {
 			const utils = new Utils()
-			console.log([compose, ...args].map(s => utils.shellEscape(s)).join(' '));
+			console.log([docker, ...args].map(s => utils.shellEscape(s)).join(' '));
 		}
 		else {
 			try {
-				execFileSync(compose, args, {encoding: 'utf8', cwd: base, stdio: 'inherit'});
+				execFileSync(docker, args, {encoding: 'utf8', cwd: base, stdio: 'inherit'});
 			} catch (err) {
 				if (err instanceof Error) {
 					console.error(err.message);


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=3859#/tickets/showTicket/3859>

#### Description

Replaces `docker-compose` with `docker compose` (`/usr/bin/docker` as default).

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
