### PR TITLE
fix: propagate command exit code instead of swallowing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Propagate the exit code from failed `docker compose` commands instead of
+  exiting 0, so callers (CI, Ansible) detect failures instead of seeing a
+  false success.
+
 ## [0.0.14] - 2025-03-26
 
 * [PR-10](https://github.com/itk-devops/devops_itkdev-docker-serverpull/1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Propagate the exit code from failed `docker compose` commands instead of
-  exiting 0, so callers (CI, Ansible) detect failures instead of seeing a
-  false success.
+* [PR-11](https://github.com/itk-devops/devops_itkdev-docker-server/pull/11)
+  Propagate command exit code instead of swallowing failed docker compose
+  commands.
 
 ## [0.0.14] - 2025-03-26
 

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -14,7 +14,7 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
   // Test env file exists.
   if (!utils.isFile(argv.base + '/' + env)) {
     console.error('The env file not found!');
-    return;
+    process.exit(1);
   }
 
   // Hack to parse the commands that should be sendt to docker.

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -13,7 +13,7 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
 
   // Test env file exists.
   if (!utils.isFile(argv.base + '/' + env)) {
-    console.error('The env file not found!');
+    console.error(`The env (${env}) file not found!`);
     process.exit(1);
   }
 

--- a/src/modules/docker.ts
+++ b/src/modules/docker.ts
@@ -83,7 +83,11 @@ export default class Docker {
 				if (err instanceof Error) {
 					console.error(err.message);
 				}
-				return null;
+
+				// Propagate the failed command's exit code so callers (CI, Ansible)
+				// detect the failure instead of seeing a false success.
+				const status = (err as {status?: number | null}).status;
+				process.exit(typeof status === 'number' ? status : 1);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://leantime.itkdev.dk/#/tickets/showTicket/6227

Failed `docker compose` commands were reported as successful, which is the root cause of Woodpecker deploys going green despite real failures (e.g. `pre-up` drush commands failing, or containers not coming online).

## Changes
- `modules/docker.ts`: on a non-zero exit from `docker compose`, exit with the underlying command's status code instead of catching the error and returning.
- `commands/docker.ts`: exit non-zero when the env file is missing.
- CHANGELOG entry under `[Unreleased]`.

## Why
`execFileSync` throws when the child exits non-zero, but the `catch` block only printed the message and returned, so the wrapper process exited `0`. Ansible's `shell`/`command` tasks therefore saw `rc=0`, the play reported `failed=0`, and Woodpecker marked the job successful.

`docker.exec()` is the wrapper's only command-execution path — a passthrough for every `docker compose` subcommand (`run`, `exec`, `up`, `pull`, …) — so this single fix covers all commands the wrapper runs.

## Note
The deployed `assets/itkdev-docker-compose-server` binary is rebuilt from source by the release workflow on tag push. After merge, a tagged release and a redeploy of the binary to the servers are required for the fix to take effect.