### PR TITLE
Clean up Taskfile and dev tooling for docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ itkdev-docker-compose-server
 node_modules
 dist
 .pkg-cache
+.task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-12](https://github.com/itk-devops/devops_itkdev-docker-server/pull/12)
+  Clean up Taskfile and dev tooling for `docker compose`.
+
 ## [0.0.14] - 2025-03-26
 
 * [PR-10](https://github.com/itk-devops/devops_itkdev-docker-serverpull/1)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Docker compose server
-Simple wrapper around docker compose
+
+Simple wrapper around `docker compose`.
 
 > [!WARNING]
 > ## Needs refactor
 > We depend on the archived and unmaintained [pkg](https://www.npmjs.com/package/pkg). Pkg recommends Node.js 21’s 
 > support for [single executable applications](https://nodejs.org/api/single-executable-applications.html) as an 
 > possible alternative.
+
+## Development
+
+``` shell
+task dev:install
+task dev:build
+```
+
+Run `task dev:build --force` to force a rebuild of the `itkdev-docker-compose-server` binary.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,15 +2,9 @@ version: '3'
 
 dotenv: [".task.env"]
 
-vars:
-  # Docker file selection
-  DOCKER_COMPOSE_FILES_OSX: '{{if eq OS "darwin"}}-f docker-compose.mac-nfs.yml{{end}}'
-  DOCKER_COMPOSE_FILES_DEFAULT: '-f docker-compose.yml {{ .DOCKER_COMPOSE_FILES_OSX }}'
-  DOCKER_COMPOSE_FILES: '{{.DOCKER_COMPOSE_FILES | default .DOCKER_COMPOSE_FILES_DEFAULT }}'
-
 tasks:
   dev:install:
-    summary: Install node packages
+    desc: Install node packages
     cmds:
       - task dev:cli -- npm install
 
@@ -18,16 +12,21 @@ tasks:
     task dev:cli -- node_modules/.bin/tsc
 
   dev:build:
-    summary: Build MacOS-x64 test build
+    desc: Build itkdev-docker-compose-server binary for local testing
     cmds:
-      - task dev:cli -- npm run buildTest
+      - task dev:cli -- npm run build:macos
+    sources:
+      - '*.json'
+      - 'src/**/*.ts'
+    generates:
+      - itkdev-docker-compose-server
 
   dev:cli:
-    summary: Performs command inside container. Expects parameter(s).
+    desc: Performs command inside container. Expects parameter(s).
     cmds:
-      - docker compose {{ .DOCKER_COMPOSE_FILES }} run --rm node {{.CLI_ARGS}}
+      - docker compose run --rm node {{.CLI_ARGS}}
 
   build:
-    summary: Build linux-x64
+    desc: Build linux-x64 for production
     cmds:
       - task dev:cli -- npm run build

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-linux-x64 --output assets/itkdev-docker-compose-server .",
-    "buildTest": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-macos-x64 --output itkdev-docker-compose-server ."
+    "build:macos": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-macos-x64 --output itkdev-docker-compose-server ."
   },
   "devDependencies": {
     "@types/node": "^17.0.33",


### PR DESCRIPTION
Completes the `docker-compose` → `docker compose` migration from #4 and refreshes it against current `develop`.

## Changes
- `Taskfile.yml`: drop the dead `DOCKER_COMPOSE_FILES*` vars (they referenced `docker-compose.mac-nfs.yml`, already removed from develop, leaving `dev:cli` broken on macOS); call `docker compose run --rm node` directly; switch task `summary` → `desc`; cache `dev:build` via `sources`/`generates`.
- `package.json`: rename `buildTest` → `build:macos`.
- `.gitignore`: ignore `.task`.
- `README.md`: document the dev workflow; tidy the intro.

## Why
The bulk of #4 (the `docker-compose.yml` rewrite and `docker-compose.mac-nfs.yml` deletion) already landed on develop, so #4 is now mostly stale/conflicting. This PR carries over the still-relevant cleanup, rebased on develop, and fixes the Taskfile which still pointed at the deleted compose file.

Credit to @rimi-itk for the original work in #4.

## Notes
- Supersedes #4 — that PR can be closed.
- The "more informative error" tweak from #4 was folded into #11 (which already edits that block), to avoid a conflict.