### PR TITLE
Release 0.0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ itkdev-docker-compose-server
 node_modules
 dist
 .pkg-cache
+.task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.14] - 2025-03-26
 
-* [PR-10](https://github.com/itk-dev/economics/pull/1)
+* [PR-10](https://github.com/itk-devops/devops_itkdev-docker-serverpull/1)
   Re-Update to node:18, re-update dependencies
 
 ## [0.0.13] - 2025-03-26
 
-* [PR-9](https://github.com/itk-dev/economics/pull/9)
+* [PR-9](https://github.com/itk-devops/devops_itkdev-docker-serverpull/9)
   Roll back to node:16 and dependencies lock from 0.0.9.
 
 ## [0.0.12] - 2025-03-26
 
-* [PR-8](https://github.com/itk-dev/economics/pull/8)
+* [PR-8](https://github.com/itk-devops/devops_itkdev-docker-serverpull/8)
   Fix binary non uploaded as release asset
 
 ## [0.0.11] - 2025-03-26
 
-* [PR-7](https://github.com/itk-dev/economics/pull/7)
+* [PR-7](https://github.com/itk-devops/devops_itkdev-docker-serverpull/7)
   Fix path in build action  
 
 ## [0.0.10] - 2025-03-26
 
-* [PR-5](https://github.com/itk-dev/economics/pull/5)
+* [PR-5](https://github.com/itk-devops/devops_itkdev-docker-serverpull/5)
   Update to node:18, update dependencies   
   Update docker setup   
   Update github actions   
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1] - 2022-04-22
 
-[Unreleased]: https://github.com/itk-dev/economics/compare/0.0.14...HEAD
+[Unreleased]: https://github.com/itk-devops/devops_itkdev-docker-servercompare/0.0.14...HEAD
 [0.0.14]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.14
 [0.0.13]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.13
 [0.0.12]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Propagate the exit code from failed `docker compose` commands instead of
+  exiting 0, so callers (CI, Ansible) detect failures instead of seeing a
+  false success.
+
 ## [0.0.14] - 2025-03-26
 
 * [PR-10](https://github.com/itk-devops/devops_itkdev-docker-serverpull/1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Propagate the exit code from failed `docker compose` commands instead of
-  exiting 0, so callers (CI, Ansible) detect failures instead of seeing a
-  false success.
+* [PR-11](https://github.com/itk-devops/devops_itkdev-docker-server/pull/11)
+  Propagate command exit code instead of swallowing failed docker compose
+  commands.
 
 ## [0.0.14] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-12](https://github.com/itk-devops/devops_itkdev-docker-server/pull/12)
+  Clean up Taskfile and dev tooling for `docker compose`.
+
 ## [0.0.14] - 2025-03-26
 
 * [PR-10](https://github.com/itk-devops/devops_itkdev-docker-serverpull/1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15] - 2026-06-16
+
 * [PR-12](https://github.com/itk-devops/devops_itkdev-docker-server/pull/12)
   Clean up Taskfile and dev tooling for `docker compose`.
 * [PR-11](https://github.com/itk-devops/devops_itkdev-docker-server/pull/11)
@@ -61,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1] - 2022-04-22
 
-[Unreleased]: https://github.com/itk-devops/devops_itkdev-docker-servercompare/0.0.14...HEAD
+[Unreleased]: https://github.com/itk-devops/devops_itkdev-docker-server/compare/0.0.15...HEAD
+[0.0.15]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.15
 [0.0.14]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.14
 [0.0.13]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.13
 [0.0.12]: https://github.com/itk-devops/devops_itkdev-docker-server/releases/tag/0.0.12

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Docker compose server
-Simple wrapper around docker compose
+
+Simple wrapper around `docker compose`.
 
 > [!WARNING]
 > ## Needs refactor
 > We depend on the archived and unmaintained [pkg](https://www.npmjs.com/package/pkg). Pkg recommends Node.js 21’s 
 > support for [single executable applications](https://nodejs.org/api/single-executable-applications.html) as an 
 > possible alternative.
+
+## Development
+
+``` shell
+task dev:install
+task dev:build
+```
+
+Run `task dev:build --force` to force a rebuild of the `itkdev-docker-compose-server` binary.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,15 +2,9 @@ version: '3'
 
 dotenv: [".task.env"]
 
-vars:
-  # Docker file selection
-  DOCKER_COMPOSE_FILES_OSX: '{{if eq OS "darwin"}}-f docker-compose.mac-nfs.yml{{end}}'
-  DOCKER_COMPOSE_FILES_DEFAULT: '-f docker-compose.yml {{ .DOCKER_COMPOSE_FILES_OSX }}'
-  DOCKER_COMPOSE_FILES: '{{.DOCKER_COMPOSE_FILES | default .DOCKER_COMPOSE_FILES_DEFAULT }}'
-
 tasks:
   dev:install:
-    summary: Install node packages
+    desc: Install node packages
     cmds:
       - task dev:cli -- npm install
 
@@ -18,16 +12,21 @@ tasks:
     task dev:cli -- node_modules/.bin/tsc
 
   dev:build:
-    summary: Build MacOS-x64 test build
+    desc: Build itkdev-docker-compose-server binary for local testing
     cmds:
-      - task dev:cli -- npm run buildTest
+      - task dev:cli -- npm run build:macos
+    sources:
+      - '*.json'
+      - 'src/**/*.ts'
+    generates:
+      - itkdev-docker-compose-server
 
   dev:cli:
-    summary: Performs command inside container. Expects parameter(s).
+    desc: Performs command inside container. Expects parameter(s).
     cmds:
-      - docker compose {{ .DOCKER_COMPOSE_FILES }} run --rm node {{.CLI_ARGS}}
+      - docker compose run --rm node {{.CLI_ARGS}}
 
   build:
-    summary: Build linux-x64
+    desc: Build linux-x64 for production
     cmds:
       - task dev:cli -- npm run build

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-linux-x64 --output assets/itkdev-docker-compose-server .",
-    "buildTest": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-macos-x64 --output itkdev-docker-compose-server ."
+    "build:macos": "node_modules/.bin/tsc && node_modules/.bin/pkg --targets node18-macos-x64 --output itkdev-docker-compose-server ."
   },
   "devDependencies": {
     "@types/node": "^17.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itkdev-docker-server",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Docker compose server site helper",
   "bin": "dist/index.js",
   "main": "dist/index.js",

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -14,7 +14,7 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
   // Test env file exists.
   if (!utils.isFile(argv.base + '/' + env)) {
     console.error('The env file not found!');
-    return;
+    process.exit(1);
   }
 
   // Hack to parse the commands that should be sendt to docker.

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -13,7 +13,7 @@ exports.handler = function (argv: { [x: string]: any; base: string; debug: any; 
 
   // Test env file exists.
   if (!utils.isFile(argv.base + '/' + env)) {
-    console.error('The env file not found!');
+    console.error(`The env (${env}) file not found!`);
     process.exit(1);
   }
 

--- a/src/modules/docker.ts
+++ b/src/modules/docker.ts
@@ -83,7 +83,11 @@ export default class Docker {
 				if (err instanceof Error) {
 					console.error(err.message);
 				}
-				return null;
+
+				// Propagate the failed command's exit code so callers (CI, Ansible)
+				// detect the failure instead of seeing a false success.
+				const status = (err as {status?: number | null}).status;
+				process.exit(typeof status === 'number' ? status : 1);
 			}
 		}
 	}


### PR DESCRIPTION
Release 0.0.15.

## Changes
- [#11](https://github.com/itk-devops/devops_itkdev-docker-server/pull/11) Propagate command exit code instead of swallowing failed docker compose commands.
- [#12](https://github.com/itk-devops/devops_itkdev-docker-server/pull/12) Clean up Taskfile and dev tooling for `docker compose`.

Plus the release commit (CHANGELOG `0.0.15` section + `package.json` bump).

## Release process
Merging this into `main` and pushing the `0.0.15` tag triggers `build_release.yml`, which rebuilds the binary and publishes the GitHub release. `main` is then back-merged into `develop`.